### PR TITLE
bug: revert previous swapped.path field data

### DIFF
--- a/subgraphs/exchange/src/mapping_ammwrapper.ts
+++ b/subgraphs/exchange/src/mapping_ammwrapper.ts
@@ -157,7 +157,6 @@ export function handleSwappedTupple(event: SwappedTuppleEvent): void {
     const decodedPathLength = ethereum.decode('uint256', pathLengthByte)!.toBigInt()
     if (decodedPathLength.gt(ZERO)) {
       let path: Array<Bytes> = []
-      path.push(entity.makerAddr)
       for (let i = 1, j = decodedPathLength.toI32(); i <= j; i++) {
         let pathAddrStart = pathByteStart + i * 32
         const pathAddrByte = Bytes.fromUint8Array(payload.subarray(pathAddrStart, pathAddrStart + 32))


### PR DESCRIPTION
## Bug fix: Revert previous swapped.path field data
1) Revert this commit: [7c053227408d](https://github.com/consenlabs/tokenlon-v5-subgraph/pull/29/commits/7c053227408d988e606dcff767170d62f565795c)
2) The entity.path should not contain entity.makerAddr data to avoid the current system querying the wrong field.

- Currently query result:
<details>
  <summary>( Please click here to expand )</summary>
    <pre><code>
```
{
  "data": {
    "swappeds": [
      {
        "id": "0x00017e8ced4a3d0bfacf8e25cf676d1beb853bd387e63dc42272dd0c17d6880f-0xd5d01b42958a2e0cc4035a3f4e2dfe36d5a7a5fa33f07a4c8cb7e422e24e8b4d-18",
        "makerAddr": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "path": [
          "0xe592427a0aece92de3edee1f18e0157c05861564",
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
        ]
      },
      {
        "id": "0x000226578155eae855f96690bd883cb3195c45ae38eb7378c015f1c451487302-0x6e700f2c5c841c7590e78d5bb9d143c9d9ec6f21c879b715c7f0ed4779a14730-94",
        "makerAddr": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
        "path": [
          "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
        ]
      },
      {
        "id": "0x0002a2db787ca10ce138ef59a88e58b93acbd62b228f7ccac2927b525e14e397-0x61a4bcdf36da8315ea49f6058035dd65f7f6e3d4fcfe44fc6b357d07c61a8a99-110",
        "makerAddr": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "path": [
          "0xe592427a0aece92de3edee1f18e0157c05861564",
          "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7"
        ]
      }
    ]
  }
}
```
    </code></pre>
</details>

- Should be expected:
<details>
  <summary>( Please click here to expand )</summary>
    <pre><code>
```
{
  "data": {
    "swappeds": [
      {
        "id": "0x00017e8ced4a3d0bfacf8e25cf676d1beb853bd387e63dc42272dd0c17d6880f-0xd5d01b42958a2e0cc4035a3f4e2dfe36d5a7a5fa33f07a4c8cb7e422e24e8b4d-18",
        "makerAddr": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "path": [
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
        ]
      },
      {
        "id": "0x000226578155eae855f96690bd883cb3195c45ae38eb7378c015f1c451487302-0x6e700f2c5c841c7590e78d5bb9d143c9d9ec6f21c879b715c7f0ed4779a14730-94",
        "makerAddr": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
        "path": [
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
        ]
      },
      {
        "id": "0x0002a2db787ca10ce138ef59a88e58b93acbd62b228f7ccac2927b525e14e397-0x61a4bcdf36da8315ea49f6058035dd65f7f6e3d4fcfe44fc6b357d07c61a8a99-110",
        "makerAddr": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "path": [
          "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
          "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
          "0x000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7"
        ]
      }
    ]
  }
}
```
    </code></pre>
</details>

## How to Verify?
1. I've already DEPLOY new version to Graph Studio (Private Site). Please go to this free GraphQL query website: [Public GraphiQL](https://cloud.hasura.io/public/graphiql).
2. On the right side, enter the OLD Endpoint URL: [https://api.studio.thegraph.com/query/34764/tokenlon-exchange/v0.0.7](https://api.studio.thegraph.com/query/34764/tokenlon-exchange/v0.0.7), and click "Connect to Endpoint" button.
3. Query the GraphQL below:
```graphql
{
  swappeds(first: 3, where: {path_not: null}) {
    id
    makerAddr
    path
  }
}
```
4. Please go to [Public GraphiQL](https://cloud.hasura.io/public/graphiql) again, and enter the NEW Endpoint URL: [https://api.studio.thegraph.com/query/34764/tokenlon-exchange/v0.0.8](https://api.studio.thegraph.com/query/34764/tokenlon-exchange/v0.0.8), then query the GraphQL again.

P.S.: You can use this [Diffchecker](https://www.diffchecker.com/) website to compare between old and new query result.
P.S.: Tokenlon product line [subgraph website](https://thegraph.com/hosted-service/subgraph/consenlabs/tokenlon-v5-exchange), and the Endpoint URL: [https://api.thegraph.com/subgraphs/name/consenlabs/tokenlon-v5-exchange](https://api.thegraph.com/subgraphs/name/consenlabs/tokenlon-v5-exchange), you can also query this for free.