### PR TITLE
feat: add limitorder subgraph to exchange subgraph

### DIFF
--- a/subgraphs/exchange/abis/LimitOrder.json
+++ b/subgraphs/exchange/abis/LimitOrder.json
@@ -1,0 +1,799 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "address", "name": "_coordinator", "type": "address" },
+      { "internalType": "address", "name": "_userProxy", "type": "address" },
+      {
+        "internalType": "contract ISpender",
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPermanentStorage",
+        "name": "_permStorage",
+        "type": "address"
+      },
+      { "internalType": "contract IWETH", "name": "_weth", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_uniswapV3RouterAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_sushiswapRouterAddress",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_feeCollector", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "AllowTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositETH",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "DisallowTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "makerFeeFactor",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "takerFeeFactor",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "profitFeeFactor",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "profitCapFactor",
+        "type": "uint16"
+      }
+    ],
+    "name": "FactorsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "allowFillHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "relayer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "profitRecipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "remainingAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFee",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ILimitOrder.FillReceipt",
+        "name": "fillReceipt",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "takerTokenProfit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "takerTokenProfitFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "takerTokenProfitBackToMaker",
+        "type": "uint256"
+      }
+    ],
+    "name": "LimitOrderFilledByProtocol",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "allowFillHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "remainingAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFee",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ILimitOrder.FillReceipt",
+        "name": "fillReceipt",
+        "type": "tuple"
+      }
+    ],
+    "name": "LimitOrderFilledByTrader",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      }
+    ],
+    "name": "OrderCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFeeCollector",
+        "type": "address"
+      }
+    ],
+    "name": "SetFeeCollector",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOperator",
+        "type": "address"
+      }
+    ],
+    "name": "TransferOwnership",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newCoordinator",
+        "type": "address"
+      }
+    ],
+    "name": "UpgradeCoordinator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newSpender",
+        "type": "address"
+      }
+    ],
+    "name": "UpgradeSpender",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EIP191_HEADER",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "EIP712_DOMAIN_NAME",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "EIP712_DOMAIN_SEPARATOR",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "EIP712_DOMAIN_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenAmount",
+            "type": "uint256"
+          },
+          { "internalType": "address", "name": "maker", "type": "address" },
+          { "internalType": "address", "name": "taker", "type": "address" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct LimitOrderLibEIP712.Order",
+        "name": "_order",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_cancelOrderMakerSig",
+        "type": "bytes"
+      }
+    ],
+    "name": "cancelLimitOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_tokenList",
+        "type": "address[]"
+      },
+      { "internalType": "address", "name": "_spender", "type": "address" }
+    ],
+    "name": "closeAllowance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "coordinator",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeCollector",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenAmount",
+            "type": "uint256"
+          },
+          { "internalType": "address", "name": "maker", "type": "address" },
+          { "internalType": "address", "name": "taker", "type": "address" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct LimitOrderLibEIP712.Order",
+        "name": "_order",
+        "type": "tuple"
+      },
+      { "internalType": "bytes", "name": "_orderMakerSig", "type": "bytes" },
+      {
+        "components": [
+          {
+            "internalType": "enum ILimitOrder.Protocol",
+            "name": "protocol",
+            "type": "uint8"
+          },
+          { "internalType": "bytes", "name": "data", "type": "bytes" },
+          {
+            "internalType": "address",
+            "name": "profitRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "protocolOutMinimum",
+            "type": "uint256"
+          },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct ILimitOrder.ProtocolParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "bytes", "name": "sig", "type": "bytes" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct ILimitOrder.CoordinatorParams",
+        "name": "_crdParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "fillLimitOrderByProtocol",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenAmount",
+            "type": "uint256"
+          },
+          { "internalType": "address", "name": "maker", "type": "address" },
+          { "internalType": "address", "name": "taker", "type": "address" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct LimitOrderLibEIP712.Order",
+        "name": "_order",
+        "type": "tuple"
+      },
+      { "internalType": "bytes", "name": "_orderMakerSig", "type": "bytes" },
+      {
+        "components": [
+          { "internalType": "address", "name": "taker", "type": "address" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenAmount",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" },
+          { "internalType": "bytes", "name": "takerSig", "type": "bytes" }
+        ],
+        "internalType": "struct ILimitOrder.TraderParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "bytes", "name": "sig", "type": "bytes" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          { "internalType": "uint64", "name": "expiry", "type": "uint64" }
+        ],
+        "internalType": "struct ILimitOrder.CoordinatorParams",
+        "name": "_crdParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "fillLimitOrderByTrader",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_signerAddress",
+        "type": "address"
+      },
+      { "internalType": "bytes32", "name": "_hash", "type": "bytes32" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" },
+      { "internalType": "bytes", "name": "_sig", "type": "bytes" }
+    ],
+    "name": "isValidSignature",
+    "outputs": [{ "internalType": "bool", "name": "isValid", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "makerFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "operator",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "permStorage",
+    "outputs": [
+      {
+        "internalType": "contract IPermanentStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "profitCapFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "profitFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_tokenList",
+        "type": "address[]"
+      },
+      { "internalType": "address", "name": "_spender", "type": "address" }
+    ],
+    "name": "setAllowance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint16", "name": "_makerFeeFactor", "type": "uint16" },
+      { "internalType": "uint16", "name": "_takerFeeFactor", "type": "uint16" },
+      {
+        "internalType": "uint16",
+        "name": "_profitFeeFactor",
+        "type": "uint16"
+      },
+      { "internalType": "uint16", "name": "_profitCapFactor", "type": "uint16" }
+    ],
+    "name": "setFactors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newFeeCollector",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeCollector",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spender",
+    "outputs": [
+      { "internalType": "contract ISpender", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sushiswapRouterAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "takerFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_newOperator", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "uniswapV3RouterAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newCoordinator",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeCoordinator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_newSpender", "type": "address" }
+    ],
+    "name": "upgradeSpender",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "userProxy",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth",
+    "outputs": [
+      { "internalType": "contract IWETH", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/subgraphs/exchange/abis/LimitOrder.json
+++ b/subgraphs/exchange/abis/LimitOrder.json
@@ -16,6 +16,11 @@
       },
       { "internalType": "contract IWETH", "name": "_weth", "type": "address" },
       {
+        "internalType": "uint256",
+        "name": "_factorActivateDelay",
+        "type": "uint256"
+      },
+      {
         "internalType": "address",
         "name": "_uniswapV3RouterAddress",
         "type": "address"
@@ -89,15 +94,107 @@
         "internalType": "uint16",
         "name": "profitFeeFactor",
         "type": "uint16"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "profitCapFactor",
-        "type": "uint16"
       }
     ],
     "name": "FactorsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "allowFillHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "relayer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "profitRecipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "makerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "takerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFilledAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "remainingAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerTokenFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerTokenFee",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ILimitOrder.FillReceipt",
+        "name": "fillReceipt",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerTakerTokenProfit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerTakerTokenProfitFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "LimitOrderFilledByProtocol",
     "type": "event"
   },
   {
@@ -288,6 +385,38 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldOperator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOperator",
+        "type": "address"
+      }
+    ],
+    "name": "OperatorChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOperator",
+        "type": "address"
+      }
+    ],
+    "name": "OperatorNominated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "bytes32",
         "name": "orderHash",
@@ -314,19 +443,6 @@
       }
     ],
     "name": "SetFeeCollector",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "newOperator",
-        "type": "address"
-      }
-    ],
-    "name": "TransferOwnership",
     "type": "event"
   },
   {
@@ -381,6 +497,20 @@
     "name": "EIP712_DOMAIN_VERSION",
     "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "activateFactors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -453,6 +583,20 @@
     "name": "depositETH",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factorActivateDelay",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factorsTimeLock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -635,9 +779,37 @@
     "type": "function"
   },
   {
+    "inputs": [{ "internalType": "address", "name": "_newOperator", "type": "address" }],
+    "name": "nominateNewOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "operator",
     "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingMakerFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingProfitFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingTakerFeeFactor",
+    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -656,16 +828,20 @@
   },
   {
     "inputs": [],
-    "name": "profitCapFactor",
+    "name": "profitFeeFactor",
     "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "profitFeeFactor",
-    "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
-    "stateMutability": "view",
+    "inputs": [
+      { "internalType": "uint16", "name": "_makerFeeFactor", "type": "uint16" },
+      { "internalType": "uint16", "name": "_takerFeeFactor", "type": "uint16" },
+      { "internalType": "uint16", "name": "_profitFeeFactor", "type": "uint16" }
+    ],
+    "name": "proposeFactors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -678,22 +854,6 @@
       { "internalType": "address", "name": "_spender", "type": "address" }
     ],
     "name": "setAllowance",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint16", "name": "_makerFeeFactor", "type": "uint16" },
-      { "internalType": "uint16", "name": "_takerFeeFactor", "type": "uint16" },
-      {
-        "internalType": "uint16",
-        "name": "_profitFeeFactor",
-        "type": "uint16"
-      },
-      { "internalType": "uint16", "name": "_profitCapFactor", "type": "uint16" }
-    ],
-    "name": "setFactors",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -714,9 +874,7 @@
   {
     "inputs": [],
     "name": "spender",
-    "outputs": [
-      { "internalType": "contract ISpender", "name": "", "type": "address" }
-    ],
+    "outputs": [{ "internalType": "contract ISpender", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -732,15 +890,6 @@
     "name": "takerFeeFactor",
     "outputs": [{ "internalType": "uint16", "name": "", "type": "uint16" }],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_newOperator", "type": "address" }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -764,9 +913,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "_newSpender", "type": "address" }
-    ],
+    "inputs": [{ "internalType": "address", "name": "_newSpender", "type": "address" }],
     "name": "upgradeSpender",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -789,9 +936,7 @@
   {
     "inputs": [],
     "name": "weth",
-    "outputs": [
-      { "internalType": "contract IWETH", "name": "", "type": "address" }
-    ],
+    "outputs": [{ "internalType": "contract IWETH", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },

--- a/subgraphs/exchange/config/goerli.json
+++ b/subgraphs/exchange/config/goerli.json
@@ -30,5 +30,13 @@
             "address": "0xfD474E4809e690626C67ECb7A908de4b9c464b99",
             "startBlock": "4851367"
         }
-    ]
+  ],
+    "LIMITORDERV1": [
+        {
+            "name": "LimitOrder",
+            "network": "goerli",
+            "address": "0x7B955545428B3a0E7520EEfF0DC30D740F290e4b",
+            "startBlock": "7497880"
+        }
+  ]
 }

--- a/subgraphs/exchange/config/goerli.json
+++ b/subgraphs/exchange/config/goerli.json
@@ -36,7 +36,9 @@
             "name": "LimitOrder",
             "network": "goerli",
             "address": "0x7B955545428B3a0E7520EEfF0DC30D740F290e4b",
-            "startBlock": "7497880"
+            "startBlock": "7497880",
+            "eventLimitOrderFilledByProtocol": "LimitOrderFilledByProtocol(indexed bytes32,indexed address,indexed address,bytes32,address,address,(address,address,uint256,uint256,uint256,uint256,uint256),uint256,uint256,uint256)",
+            "handleLimitOrderFilledByProtocol": "handleLimitOrderFilledByProtocolGoerli"
         }
     ]
 }

--- a/subgraphs/exchange/config/goerli.json
+++ b/subgraphs/exchange/config/goerli.json
@@ -30,7 +30,7 @@
             "address": "0xfD474E4809e690626C67ECb7A908de4b9c464b99",
             "startBlock": "4851367"
         }
-  ],
+    ],
     "LIMITORDERV1": [
         {
             "name": "LimitOrder",
@@ -38,5 +38,5 @@
             "address": "0x7B955545428B3a0E7520EEfF0DC30D740F290e4b",
             "startBlock": "7497880"
         }
-  ]
+    ]
 }

--- a/subgraphs/exchange/config/mainnet.json
+++ b/subgraphs/exchange/config/mainnet.json
@@ -36,7 +36,7 @@
             "address": "0xfD6C2d2499b1331101726A8AC68CCc9Da3fAB54F",
             "startBlock": "12792553"
         }
-  ],
+    ],
     "LIMITORDERV1": [
         {
             "name": "LimitOrder",
@@ -45,5 +45,5 @@
             "startBlock": "16066333",
             "// comment": "The contract has not yet been deployed to the mainnet."
         }
-  ]
+    ]
 }

--- a/subgraphs/exchange/config/mainnet.json
+++ b/subgraphs/exchange/config/mainnet.json
@@ -41,9 +41,10 @@
         {
             "name": "LimitOrder",
             "network": "mainnet",
-            "address": "0x0000000000000000000000000000000000000000",
-            "startBlock": "16066333",
-            "// comment": "The contract has not yet been deployed to the mainnet."
+            "address": "0x623a6B3424f3d5E2eC677D5bb92BA12A9dc4f71A",
+            "startBlock": "16525456",
+            "eventLimitOrderFilledByProtocol": "LimitOrderFilledByProtocol(indexed bytes32,indexed address,indexed address,bytes32,address,address,(address,address,uint256,uint256,uint256,uint256,uint256),uint256,uint256)",
+            "handleLimitOrderFilledByProtocol": "handleLimitOrderFilledByProtocol"
         }
     ]
 }

--- a/subgraphs/exchange/config/mainnet.json
+++ b/subgraphs/exchange/config/mainnet.json
@@ -36,5 +36,14 @@
             "address": "0xfD6C2d2499b1331101726A8AC68CCc9Da3fAB54F",
             "startBlock": "12792553"
         }
-    ]
+  ],
+    "LIMITORDERV1": [
+        {
+            "name": "LimitOrder",
+            "network": "mainnet",
+            "address": "0x0000000000000000000000000000000000000000",
+            "startBlock": "16066333",
+            "// comment": "The contract has not yet been deployed to the mainnet."
+        }
+  ]
 }

--- a/subgraphs/exchange/exchange.graphql
+++ b/subgraphs/exchange/exchange.graphql
@@ -93,6 +93,106 @@ type SubsidizedSwapped @entity {
   path: [Bytes!]
 }
 
+# For LimitOrder contract
+type LimitOrderFilledByProtocol @entity(immutable: true) {
+  id: ID!
+  orderHash: Bytes! # bytes32
+  maker: Bytes! # address
+  taker: Bytes! # address
+  allowFillHash: Bytes! # bytes32
+  relayer: Bytes! # address
+  profitRecipient: Bytes! # address
+  fillReceipt_makerToken: Bytes! # address
+  fillReceipt_takerToken: Bytes! # address
+  fillReceipt_makerTokenFilledAmount: BigInt! # uint256
+  fillReceipt_takerTokenFilledAmount: BigInt! # uint256
+  fillReceipt_remainingAmount: BigInt! # uint256
+  fillReceipt_makerTokenFee: BigInt! # uint256
+  fillReceipt_takerTokenFee: BigInt! # uint256
+  takerTokenProfit: BigInt! # uint256
+  takerTokenProfitFee: BigInt! # uint256
+  takerTokenProfitBackToMaker: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type LimitOrderFilledByTrader @entity(immutable: true) {
+  id: ID!
+  orderHash: Bytes! # bytes32
+  maker: Bytes! # address
+  taker: Bytes! # address
+  allowFillHash: Bytes! # bytes32
+  recipient: Bytes! # address
+  fillReceipt_makerToken: Bytes! # address
+  fillReceipt_takerToken: Bytes! # address
+  fillReceipt_makerTokenFilledAmount: BigInt! # uint256
+  fillReceipt_takerTokenFilledAmount: BigInt! # uint256
+  fillReceipt_remainingAmount: BigInt! # uint256
+  fillReceipt_makerTokenFee: BigInt! # uint256
+  fillReceipt_takerTokenFee: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type OrderCancelled @entity(immutable: true) {
+  id: ID!
+  orderHash: Bytes! # bytes32
+  maker: Bytes! # address
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+enum OrderStatus {
+  Normal
+  Cancelled
+  FullyFilled
+}
+
+enum LimitOrderTypes {
+  ByProtocol
+  ByTrader
+}
+
+type Order @entity(immutable: false) {
+  id: ID! # orderHash
+  limitOrderFilledId: [String!]! # One-to-many relationship
+  orderStatus: OrderStatus!
+  maker: Bytes! # address
+  makerToken: Bytes! # address
+  takerToken: Bytes! # address
+  firstFilledTime: BigInt!
+  lastFilledOrCancelledTime: BigInt!
+}
+
+type LimitOrder @entity(immutable: true) {
+  id: ID!
+  orderId: String! # Order! # orderHash
+  limitOrderType: LimitOrderTypes!
+  maker: Bytes! # address
+  taker: Bytes! # address
+  makerToken: Bytes! # address
+  takerToken: Bytes! # address
+  allowFillHash: Bytes! # bytes32
+  makerTokenFilledAmount: BigInt! # uint256
+  takerTokenFilledAmount: BigInt! # uint256
+  remainingAmount: BigInt! # uint256
+  makerTokenFee: BigInt! # uint256
+  takerTokenFee: BigInt! # uint256
+  recipient: Bytes! # address # Only used by LimitOrderFilledByTrader event
+  relayer: Bytes! # address # Only used by LimitOrderFilledByProtocol event
+  profitRecipient: Bytes! # address # Only used by LimitOrderFilledByProtocol event
+  takerTokenProfit: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
+  takerTokenProfitFee: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
+  takerTokenProfitBackToMaker: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# Shared entities
 type TradedToken @entity {
   id: ID!
   address: Bytes! # bytes32

--- a/subgraphs/exchange/exchange.graphql
+++ b/subgraphs/exchange/exchange.graphql
@@ -164,7 +164,8 @@ type Order @entity(immutable: false) {
   makerToken: Bytes! # address
   takerToken: Bytes! # address
   firstFilledTime: BigInt!
-  lastFilledOrCancelledTime: BigInt!
+  lastFilledTime: BigInt!
+  cancelledTime: BigInt!
 }
 
 type LimitOrder @entity(immutable: true) {

--- a/subgraphs/exchange/exchange.graphql
+++ b/subgraphs/exchange/exchange.graphql
@@ -109,9 +109,8 @@ type LimitOrderFilledByProtocol @entity(immutable: true) {
   fillReceiptRemainingAmount: BigInt! # uint256
   fillReceiptMakerTokenFee: BigInt! # uint256
   fillReceiptTakerTokenFee: BigInt! # uint256
-  takerTokenProfit: BigInt! # uint256
-  takerTokenProfitFee: BigInt! # uint256
-  takerTokenProfitBackToMaker: BigInt! # uint256
+  relayerTakerTokenProfit: BigInt! # uint256
+  relayerTakerTokenProfitFee: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
@@ -185,9 +184,8 @@ type LimitOrder @entity(immutable: true) {
   recipient: Bytes! # address # Only used by LimitOrderFilledByTrader event
   relayer: Bytes! # address # Only used by LimitOrderFilledByProtocol event
   profitRecipient: Bytes! # address # Only used by LimitOrderFilledByProtocol event
-  takerTokenProfit: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
-  takerTokenProfitFee: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
-  takerTokenProfitBackToMaker: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
+  relayerTakerTokenProfit: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
+  relayerTakerTokenProfitFee: BigInt! # uint256 # Only used by LimitOrderFilledByProtocol event
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!

--- a/subgraphs/exchange/exchange.graphql
+++ b/subgraphs/exchange/exchange.graphql
@@ -102,13 +102,13 @@ type LimitOrderFilledByProtocol @entity(immutable: true) {
   allowFillHash: Bytes! # bytes32
   relayer: Bytes! # address
   profitRecipient: Bytes! # address
-  fillReceipt_makerToken: Bytes! # address
-  fillReceipt_takerToken: Bytes! # address
-  fillReceipt_makerTokenFilledAmount: BigInt! # uint256
-  fillReceipt_takerTokenFilledAmount: BigInt! # uint256
-  fillReceipt_remainingAmount: BigInt! # uint256
-  fillReceipt_makerTokenFee: BigInt! # uint256
-  fillReceipt_takerTokenFee: BigInt! # uint256
+  fillReceiptMakerToken: Bytes! # address
+  fillReceiptTakerToken: Bytes! # address
+  fillReceiptMakerTokenFilledAmount: BigInt! # uint256
+  fillReceiptTakerTokenFilledAmount: BigInt! # uint256
+  fillReceiptRemainingAmount: BigInt! # uint256
+  fillReceiptMakerTokenFee: BigInt! # uint256
+  fillReceiptTakerTokenFee: BigInt! # uint256
   takerTokenProfit: BigInt! # uint256
   takerTokenProfitFee: BigInt! # uint256
   takerTokenProfitBackToMaker: BigInt! # uint256
@@ -124,13 +124,13 @@ type LimitOrderFilledByTrader @entity(immutable: true) {
   taker: Bytes! # address
   allowFillHash: Bytes! # bytes32
   recipient: Bytes! # address
-  fillReceipt_makerToken: Bytes! # address
-  fillReceipt_takerToken: Bytes! # address
-  fillReceipt_makerTokenFilledAmount: BigInt! # uint256
-  fillReceipt_takerTokenFilledAmount: BigInt! # uint256
-  fillReceipt_remainingAmount: BigInt! # uint256
-  fillReceipt_makerTokenFee: BigInt! # uint256
-  fillReceipt_takerTokenFee: BigInt! # uint256
+  fillReceiptMakerToken: Bytes! # address
+  fillReceiptTakerToken: Bytes! # address
+  fillReceiptMakerTokenFilledAmount: BigInt! # uint256
+  fillReceiptTakerTokenFilledAmount: BigInt! # uint256
+  fillReceiptRemainingAmount: BigInt! # uint256
+  fillReceiptMakerTokenFee: BigInt! # uint256
+  fillReceiptTakerTokenFee: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!

--- a/subgraphs/exchange/src/mapping_limitorder.ts
+++ b/subgraphs/exchange/src/mapping_limitorder.ts
@@ -14,13 +14,13 @@ export function handleLimitOrderFilledByProtocol(event: LimitOrderFilledByProtoc
   entity.allowFillHash = event.params.allowFillHash
   entity.relayer = event.params.relayer
   entity.profitRecipient = event.params.profitRecipient
-  entity.fillReceipt_makerToken = event.params.fillReceipt.makerToken
-  entity.fillReceipt_takerToken = event.params.fillReceipt.takerToken
-  entity.fillReceipt_makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
-  entity.fillReceipt_takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
-  entity.fillReceipt_remainingAmount = event.params.fillReceipt.remainingAmount
-  entity.fillReceipt_makerTokenFee = event.params.fillReceipt.makerTokenFee
-  entity.fillReceipt_takerTokenFee = event.params.fillReceipt.takerTokenFee
+  entity.fillReceiptMakerToken = event.params.fillReceipt.makerToken
+  entity.fillReceiptTakerToken = event.params.fillReceipt.takerToken
+  entity.fillReceiptMakerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+  entity.fillReceiptTakerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+  entity.fillReceiptRemainingAmount = event.params.fillReceipt.remainingAmount
+  entity.fillReceiptMakerTokenFee = event.params.fillReceipt.makerTokenFee
+  entity.fillReceiptTakerTokenFee = event.params.fillReceipt.takerTokenFee
   entity.takerTokenProfit = event.params.takerTokenProfit
   entity.takerTokenProfitFee = event.params.takerTokenProfitFee
   entity.takerTokenProfitBackToMaker = event.params.takerTokenProfitBackToMaker
@@ -32,8 +32,8 @@ export function handleLimitOrderFilledByProtocol(event: LimitOrderFilledByProtoc
   entity.save()
 
   // Record the tokens data of this LimitOrderFilledByProtocol event
-  addTradedToken(entity.fillReceipt_makerToken, event.block.timestamp)
-  addTradedToken(entity.fillReceipt_takerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceiptMakerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceiptTakerToken, event.block.timestamp)
 
   // Get the order hash as order entity id
   const orderId = event.params.orderHash.toHex()
@@ -114,13 +114,13 @@ export function handleLimitOrderFilledByTrader(event: LimitOrderFilledByTraderEv
   entity.taker = event.params.taker
   entity.allowFillHash = event.params.allowFillHash
   entity.recipient = event.params.recipient
-  entity.fillReceipt_makerToken = event.params.fillReceipt.makerToken
-  entity.fillReceipt_takerToken = event.params.fillReceipt.takerToken
-  entity.fillReceipt_makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
-  entity.fillReceipt_takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
-  entity.fillReceipt_remainingAmount = event.params.fillReceipt.remainingAmount
-  entity.fillReceipt_makerTokenFee = event.params.fillReceipt.makerTokenFee
-  entity.fillReceipt_takerTokenFee = event.params.fillReceipt.takerTokenFee
+  entity.fillReceiptMakerToken = event.params.fillReceipt.makerToken
+  entity.fillReceiptTakerToken = event.params.fillReceipt.takerToken
+  entity.fillReceiptMakerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+  entity.fillReceiptTakerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+  entity.fillReceiptRemainingAmount = event.params.fillReceipt.remainingAmount
+  entity.fillReceiptMakerTokenFee = event.params.fillReceipt.makerTokenFee
+  entity.fillReceiptTakerTokenFee = event.params.fillReceipt.takerTokenFee
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
@@ -129,8 +129,8 @@ export function handleLimitOrderFilledByTrader(event: LimitOrderFilledByTraderEv
   entity.save()
 
   // Record the tokens data of this LimitOrderFilledByProtocol event
-  addTradedToken(entity.fillReceipt_makerToken, event.block.timestamp)
-  addTradedToken(entity.fillReceipt_takerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceiptMakerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceiptTakerToken, event.block.timestamp)
 
   // Get the order hash as order entity id
   const orderId = event.params.orderHash.toHex()

--- a/subgraphs/exchange/src/mapping_limitorder.ts
+++ b/subgraphs/exchange/src/mapping_limitorder.ts
@@ -1,5 +1,10 @@
 import { BigInt, Address, Bytes, log } from '@graphprotocol/graph-ts'
-import { LimitOrderFilledByProtocol as LimitOrderFilledByProtocolEvent, LimitOrderFilledByTrader as LimitOrderFilledByTraderEvent, OrderCancelled as OrderCancelledEvent } from '../generated/LimitOrder/LimitOrder'
+import {
+  LimitOrderFilledByProtocol as LimitOrderFilledByProtocolEvent,
+  LimitOrderFilledByProtocol1 as LimitOrderFilledByProtocolGoerliEvent,
+  LimitOrderFilledByTrader as LimitOrderFilledByTraderEvent,
+  OrderCancelled as OrderCancelledEvent
+} from '../generated/LimitOrder/LimitOrder'
 import { LimitOrderFilledByProtocol as LimitOrderFilledByProtocolEntity, LimitOrderFilledByTrader as LimitOrderFilledByTraderEntity, OrderCancelled as OrderCancelledEntity, Order as OrderEntity, LimitOrder as LimitOrderEntity } from '../generated/schema'
 import { addTradedToken, getEventID } from './helper'
 
@@ -33,9 +38,9 @@ export function handleLimitOrderFilledByProtocol(event: LimitOrderFilledByProtoc
   entity.fillReceiptRemainingAmount = event.params.fillReceipt.remainingAmount
   entity.fillReceiptMakerTokenFee = event.params.fillReceipt.makerTokenFee
   entity.fillReceiptTakerTokenFee = event.params.fillReceipt.takerTokenFee
-  entity.takerTokenProfit = event.params.takerTokenProfit
-  entity.takerTokenProfitFee = event.params.takerTokenProfitFee
-  entity.takerTokenProfitBackToMaker = event.params.takerTokenProfitBackToMaker
+  // Event parameters of relayerTakerTokenProfitFee, relayerTakerTokenProfitFee for LimitOrder on Mainnet
+  entity.relayerTakerTokenProfit = event.params.relayerTakerTokenProfit
+  entity.relayerTakerTokenProfitFee = event.params.relayerTakerTokenProfitFee
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
@@ -94,9 +99,102 @@ export function handleLimitOrderFilledByProtocol(event: LimitOrderFilledByProtoc
     limitOrderEntity.takerTokenFee = event.params.fillReceipt.takerTokenFee
     limitOrderEntity.relayer = event.params.relayer as Bytes
     limitOrderEntity.profitRecipient = event.params.profitRecipient as Bytes
-    limitOrderEntity.takerTokenProfit = event.params.takerTokenProfit
-    limitOrderEntity.takerTokenProfitFee = event.params.takerTokenProfitFee
-    limitOrderEntity.takerTokenProfitBackToMaker = event.params.takerTokenProfitBackToMaker
+    // Event parameters of relayerTakerTokenProfitFee, relayerTakerTokenProfitFee for LimitOrder on Mainnet
+    limitOrderEntity.relayerTakerTokenProfit = event.params.relayerTakerTokenProfit
+    limitOrderEntity.relayerTakerTokenProfitFee = event.params.relayerTakerTokenProfitFee
+    // recipient is only used by the LimitOrderFilledByTrader event.
+    limitOrderEntity.recipient = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
+    limitOrderEntity.blockNumber = event.block.number
+    limitOrderEntity.blockTimestamp = event.block.timestamp
+    limitOrderEntity.transactionHash = event.transaction.hash
+  }
+  log.info('LimitOrderFilledByProtocol entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), limitOrderEntity.id])
+  // Entity must be saved after setting
+  limitOrderEntity.save()
+}
+
+// Handling function when the LimitOrderFilledByProtocolGoerli event occurs
+export function handleLimitOrderFilledByProtocolGoerli(event: LimitOrderFilledByProtocolGoerliEvent): void {
+  // Record the data of this LimitOrderFilledByProtocol event
+  const eventId = getEventID(event)
+  const entity = new LimitOrderFilledByProtocolEntity(eventId)
+  entity.orderHash = event.params.orderHash
+  entity.maker = event.params.maker
+  entity.taker = event.params.taker
+  entity.allowFillHash = event.params.allowFillHash
+  entity.relayer = event.params.relayer
+  entity.profitRecipient = event.params.profitRecipient
+  entity.fillReceiptMakerToken = event.params.fillReceipt.makerToken
+  entity.fillReceiptTakerToken = event.params.fillReceipt.takerToken
+  entity.fillReceiptMakerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+  entity.fillReceiptTakerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+  entity.fillReceiptRemainingAmount = event.params.fillReceipt.remainingAmount
+  entity.fillReceiptMakerTokenFee = event.params.fillReceipt.makerTokenFee
+  entity.fillReceiptTakerTokenFee = event.params.fillReceipt.takerTokenFee
+  // Event parameters of takerTokenProfit, takerTokenProfitFee for LimitOrder on Goerli
+  entity.relayerTakerTokenProfit = event.params.takerTokenProfit
+  entity.relayerTakerTokenProfitFee = event.params.takerTokenProfitFee
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  log.info('LimitOrderFilledByProtocol entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), entity.id])
+  // Entity must be saved after setting
+  entity.save()
+
+  // Record the tokens data of this LimitOrderFilledByProtocol event
+  addTradedToken(entity.fillReceiptMakerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceiptTakerToken, event.block.timestamp)
+
+  // Get the order hash as order entity id
+  const orderId = event.params.orderHash.toHex()
+  // Load old or create new Order entity
+  let orderEntity = OrderEntity.load(orderId)
+  if (orderEntity == null) {
+    orderEntity = new OrderEntity(orderId)
+    orderEntity.orderStatus = OrderStatus.Normal
+    orderEntity.maker = event.params.maker
+    orderEntity.makerToken = event.params.fillReceipt.makerToken
+    orderEntity.takerToken = event.params.fillReceipt.takerToken
+    orderEntity.firstFilledTime = event.block.timestamp
+    orderEntity.cancelledTime = BigInt.fromI32(0)
+    // Set the relationship of the first LimitOrderFilled entity under the same orderHash
+    orderEntity.limitOrderFilledId = new Array<string>(0)
+    log.info('Order entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), orderEntity.id])
+  }
+  orderEntity.lastFilledTime = event.block.timestamp
+  // Set the relationship of this LimitOrderFilled entity under the same orderHash
+  const limitOrderFilledArray = orderEntity.limitOrderFilledId
+  limitOrderFilledArray.push(eventId)
+  orderEntity.limitOrderFilledId = limitOrderFilledArray
+  // If the order is filled all for this time
+  if (event.params.fillReceipt.remainingAmount.equals(BigInt.fromI32(0))) {
+    orderEntity.orderStatus = OrderStatus.FullyFilled
+    log.info('Order is filled all, the order hash: {}.', [orderEntity.id])
+  }
+  // Entity must be saved after setting
+  orderEntity.save()
+
+  // Load old or create new LimitOrder entity
+  let limitOrderEntity = LimitOrderEntity.load(eventId)
+  if (limitOrderEntity == null) {
+    limitOrderEntity = new LimitOrderEntity(eventId)
+    limitOrderEntity.orderId = orderId
+    limitOrderEntity.limitOrderType = LimitOrderTypes.ByProtocol
+    limitOrderEntity.maker = event.params.maker as Bytes
+    limitOrderEntity.taker = event.params.taker as Bytes
+    limitOrderEntity.makerToken = event.params.fillReceipt.makerToken as Bytes
+    limitOrderEntity.takerToken = event.params.fillReceipt.takerToken as Bytes
+    limitOrderEntity.allowFillHash = event.params.allowFillHash
+    limitOrderEntity.makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+    limitOrderEntity.takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+    limitOrderEntity.remainingAmount = event.params.fillReceipt.remainingAmount
+    limitOrderEntity.makerTokenFee = event.params.fillReceipt.makerTokenFee
+    limitOrderEntity.takerTokenFee = event.params.fillReceipt.takerTokenFee
+    limitOrderEntity.relayer = event.params.relayer as Bytes
+    limitOrderEntity.profitRecipient = event.params.profitRecipient as Bytes
+    // Event parameters of takerTokenProfit, takerTokenProfitFee for LimitOrder on Goerli
+    limitOrderEntity.relayerTakerTokenProfit = event.params.takerTokenProfit
+    limitOrderEntity.relayerTakerTokenProfitFee = event.params.takerTokenProfitFee
     // recipient is only used by the LimitOrderFilledByTrader event.
     limitOrderEntity.recipient = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
     limitOrderEntity.blockNumber = event.block.number
@@ -182,13 +280,12 @@ export function handleLimitOrderFilledByTrader(event: LimitOrderFilledByTraderEv
     limitOrderEntity.makerTokenFee = event.params.fillReceipt.makerTokenFee
     limitOrderEntity.takerTokenFee = event.params.fillReceipt.takerTokenFee
     limitOrderEntity.recipient = event.params.recipient as Bytes
-    // relayer, profitRecipient, takerTokenProfit, takerTokenProfitFee, takerTokenProfitBackToMaker
+    // relayer, profitRecipient, relayerTakerTokenProfit, relayerTakerTokenProfitFee
     // are only used by the LimitOrderFilledByProtocol event.
     limitOrderEntity.relayer = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
     limitOrderEntity.profitRecipient = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
-    limitOrderEntity.takerTokenProfit = BigInt.fromI32(0)
-    limitOrderEntity.takerTokenProfitFee = BigInt.fromI32(0)
-    limitOrderEntity.takerTokenProfitBackToMaker = BigInt.fromI32(0)
+    limitOrderEntity.relayerTakerTokenProfit = BigInt.fromI32(0)
+    limitOrderEntity.relayerTakerTokenProfitFee = BigInt.fromI32(0)
     limitOrderEntity.blockNumber = event.block.number
     limitOrderEntity.blockTimestamp = event.block.timestamp
     limitOrderEntity.transactionHash = event.transaction.hash

--- a/subgraphs/exchange/src/mapping_limitorder.ts
+++ b/subgraphs/exchange/src/mapping_limitorder.ts
@@ -1,0 +1,227 @@
+import { BigInt, Address, Bytes, log } from '@graphprotocol/graph-ts'
+import { LimitOrderFilledByProtocol as LimitOrderFilledByProtocolEvent, LimitOrderFilledByTrader as LimitOrderFilledByTraderEvent, OrderCancelled as OrderCancelledEvent } from '../generated/LimitOrder/LimitOrder'
+import { LimitOrderFilledByProtocol as LimitOrderFilledByProtocolEntity, LimitOrderFilledByTrader as LimitOrderFilledByTraderEntity, OrderCancelled as OrderCancelledEntity, Order as OrderEntity, LimitOrder as LimitOrderEntity } from '../generated/schema'
+import { addTradedToken, getEventID } from './helper'
+
+// Handling function when the LimitOrderFilledByProtocol event occurs
+export function handleLimitOrderFilledByProtocol(event: LimitOrderFilledByProtocolEvent): void {
+  // Record the data of this LimitOrderFilledByProtocol event
+  const eventId = getEventID(event)
+  const entity = new LimitOrderFilledByProtocolEntity(eventId)
+  entity.orderHash = event.params.orderHash
+  entity.maker = event.params.maker
+  entity.taker = event.params.taker
+  entity.allowFillHash = event.params.allowFillHash
+  entity.relayer = event.params.relayer
+  entity.profitRecipient = event.params.profitRecipient
+  entity.fillReceipt_makerToken = event.params.fillReceipt.makerToken
+  entity.fillReceipt_takerToken = event.params.fillReceipt.takerToken
+  entity.fillReceipt_makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+  entity.fillReceipt_takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+  entity.fillReceipt_remainingAmount = event.params.fillReceipt.remainingAmount
+  entity.fillReceipt_makerTokenFee = event.params.fillReceipt.makerTokenFee
+  entity.fillReceipt_takerTokenFee = event.params.fillReceipt.takerTokenFee
+  entity.takerTokenProfit = event.params.takerTokenProfit
+  entity.takerTokenProfitFee = event.params.takerTokenProfitFee
+  entity.takerTokenProfitBackToMaker = event.params.takerTokenProfitBackToMaker
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  log.info('LimitOrderFilledByProtocol entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), entity.id])
+  // Entity must be saved after setting
+  entity.save()
+
+  // Record the tokens data of this LimitOrderFilledByProtocol event
+  addTradedToken(entity.fillReceipt_makerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceipt_takerToken, event.block.timestamp)
+
+  // Get the order hash as order entity id
+  const orderId = event.params.orderHash.toHex()
+  // Load old or create new Order entity
+  let orderEntity = OrderEntity.load(orderId)
+  if (orderEntity == null) {
+    orderEntity = new OrderEntity(orderId)
+    orderEntity.orderStatus = 'Normal'
+    orderEntity.maker = event.params.maker
+    orderEntity.makerToken = event.params.fillReceipt.makerToken
+    orderEntity.takerToken = event.params.fillReceipt.takerToken
+    orderEntity.firstFilledTime = event.block.timestamp
+    orderEntity.lastFilledOrCancelledTime = event.block.timestamp
+    // Set the relationship of the first LimitOrderFilled entity under the same orderHash
+    const limitOrderFilledArray = new Array<string>(0)
+    limitOrderFilledArray.push(eventId)
+    orderEntity.limitOrderFilledId = limitOrderFilledArray
+    log.info('Order entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), orderEntity.id])
+    // If the order is filled all for the first time
+    if (event.params.fillReceipt.remainingAmount.equals(BigInt.fromI32(0))) {
+      orderEntity.orderStatus = 'FullyFilled'
+      log.info('Order is filled all, the order hash: {}.', [orderEntity.id])
+    }
+  } else {
+    // Set the relationship of this LimitOrderFilled entity under the same orderHash
+    const limitOrderFilledArray = orderEntity.limitOrderFilledId
+    limitOrderFilledArray.push(eventId)
+    orderEntity.limitOrderFilledId = limitOrderFilledArray
+    orderEntity.lastFilledOrCancelledTime = event.block.timestamp
+    // If the order is filled all for this time
+    if (event.params.fillReceipt.remainingAmount.equals(BigInt.fromI32(0))) {
+      orderEntity.orderStatus = 'FullyFilled'
+      log.info('Order is filled all, the order hash: {}.', [orderEntity.id])
+    }
+  }
+  // Entity must be saved after setting
+  orderEntity.save()
+
+  // Load old or create new LimitOrder entity
+  let limitOrderEntity = LimitOrderEntity.load(eventId)
+  if (limitOrderEntity == null) {
+    limitOrderEntity = new LimitOrderEntity(eventId)
+    limitOrderEntity.orderId = orderId
+    limitOrderEntity.limitOrderType = 'ByProtocol'
+    limitOrderEntity.maker = event.params.maker as Bytes
+    limitOrderEntity.taker = event.params.taker as Bytes
+    limitOrderEntity.makerToken = event.params.fillReceipt.makerToken as Bytes
+    limitOrderEntity.takerToken = event.params.fillReceipt.takerToken as Bytes
+    limitOrderEntity.allowFillHash = event.params.allowFillHash
+    limitOrderEntity.makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+    limitOrderEntity.takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+    limitOrderEntity.remainingAmount = event.params.fillReceipt.remainingAmount
+    limitOrderEntity.makerTokenFee = event.params.fillReceipt.makerTokenFee
+    limitOrderEntity.takerTokenFee = event.params.fillReceipt.takerTokenFee
+    limitOrderEntity.relayer = event.params.relayer as Bytes
+    limitOrderEntity.profitRecipient = event.params.profitRecipient as Bytes
+    limitOrderEntity.takerTokenProfit = event.params.takerTokenProfit
+    limitOrderEntity.takerTokenProfitFee = event.params.takerTokenProfitFee
+    limitOrderEntity.takerTokenProfitBackToMaker = event.params.takerTokenProfitBackToMaker
+    // recipient is only used by the LimitOrderFilledByTrader event.
+    limitOrderEntity.recipient = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
+    limitOrderEntity.blockNumber = event.block.number
+    limitOrderEntity.blockTimestamp = event.block.timestamp
+    limitOrderEntity.transactionHash = event.transaction.hash
+  }
+  log.info('LimitOrderFilledByProtocol entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), limitOrderEntity.id])
+  // Entity must be saved after setting
+  limitOrderEntity.save()
+}
+
+// Handling function when the LimitOrderFilledByTrader event occurs
+export function handleLimitOrderFilledByTrader(event: LimitOrderFilledByTraderEvent): void {
+  // Record the data of this LimitOrderFilledByTrader event
+  const eventId = getEventID(event)
+  const entity = new LimitOrderFilledByTraderEntity(eventId)
+  entity.orderHash = event.params.orderHash
+  entity.maker = event.params.maker
+  entity.taker = event.params.taker
+  entity.allowFillHash = event.params.allowFillHash
+  entity.recipient = event.params.recipient
+  entity.fillReceipt_makerToken = event.params.fillReceipt.makerToken
+  entity.fillReceipt_takerToken = event.params.fillReceipt.takerToken
+  entity.fillReceipt_makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+  entity.fillReceipt_takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+  entity.fillReceipt_remainingAmount = event.params.fillReceipt.remainingAmount
+  entity.fillReceipt_makerTokenFee = event.params.fillReceipt.makerTokenFee
+  entity.fillReceipt_takerTokenFee = event.params.fillReceipt.takerTokenFee
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  log.info('LimitOrderFilledByTrader entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), entity.id])
+  // Entity must be saved after setting
+  entity.save()
+
+  // Record the tokens data of this LimitOrderFilledByProtocol event
+  addTradedToken(entity.fillReceipt_makerToken, event.block.timestamp)
+  addTradedToken(entity.fillReceipt_takerToken, event.block.timestamp)
+
+  // Get the order hash as order entity id
+  const orderId = event.params.orderHash.toHex()
+  // Load old or create new Order entity
+  let orderEntity = OrderEntity.load(orderId)
+  if (orderEntity == null) {
+    orderEntity = new OrderEntity(orderId)
+    orderEntity.orderStatus = 'Normal'
+    orderEntity.maker = event.params.maker
+    orderEntity.makerToken = event.params.fillReceipt.makerToken
+    orderEntity.takerToken = event.params.fillReceipt.takerToken
+    orderEntity.firstFilledTime = event.block.timestamp
+    orderEntity.lastFilledOrCancelledTime = event.block.timestamp
+    // Set the relationship of the first LimitOrderFilled entity under the same orderHash
+    const limitOrderFilledArray = new Array<string>(0)
+    limitOrderFilledArray.push(eventId)
+    orderEntity.limitOrderFilledId = limitOrderFilledArray
+    log.info('Order entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), orderEntity.id])
+    // If the order is filled all for the first time
+    if (event.params.fillReceipt.remainingAmount.equals(BigInt.fromI32(0))) {
+      orderEntity.orderStatus = 'FullyFilled'
+      log.info('Order is filled all, the order hash: {}.', [orderEntity.id])
+    }
+  } else {
+    // Set the relationship of this LimitOrderFilled entity under the same orderHash
+    const limitOrderFilledArray = orderEntity.limitOrderFilledId
+    limitOrderFilledArray.push(eventId)
+    orderEntity.limitOrderFilledId = limitOrderFilledArray
+    orderEntity.lastFilledOrCancelledTime = event.block.timestamp
+    // If the order is filled all for this time
+    if (event.params.fillReceipt.remainingAmount.equals(BigInt.fromI32(0))) {
+      orderEntity.orderStatus = 'FullyFilled'
+      log.info('Order is filled all, the order hash: {}.', [orderEntity.id])
+    }
+  }
+  // Entity must be saved after setting
+  orderEntity.save()
+
+  // Load old or create new LimitOrder entity
+  let limitOrderEntity = LimitOrderEntity.load(eventId)
+  if (limitOrderEntity == null) {
+    limitOrderEntity = new LimitOrderEntity(eventId)
+    limitOrderEntity.orderId = orderId
+    limitOrderEntity.limitOrderType = 'ByTrader'
+    limitOrderEntity.maker = event.params.maker as Bytes
+    limitOrderEntity.taker = event.params.taker as Bytes
+    limitOrderEntity.makerToken = event.params.fillReceipt.makerToken as Bytes
+    limitOrderEntity.takerToken = event.params.fillReceipt.takerToken as Bytes
+    limitOrderEntity.allowFillHash = event.params.allowFillHash
+    limitOrderEntity.makerTokenFilledAmount = event.params.fillReceipt.makerTokenFilledAmount
+    limitOrderEntity.takerTokenFilledAmount = event.params.fillReceipt.takerTokenFilledAmount
+    limitOrderEntity.remainingAmount = event.params.fillReceipt.remainingAmount
+    limitOrderEntity.makerTokenFee = event.params.fillReceipt.makerTokenFee
+    limitOrderEntity.takerTokenFee = event.params.fillReceipt.takerTokenFee
+    limitOrderEntity.recipient = event.params.recipient as Bytes
+    // relayer, profitRecipient, takerTokenProfit, takerTokenProfitFee, takerTokenProfitBackToMaker
+    // are only used by the LimitOrderFilledByProtocol event.
+    limitOrderEntity.relayer = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
+    limitOrderEntity.profitRecipient = Address.fromString('0x0000000000000000000000000000000000000000') as Bytes
+    limitOrderEntity.takerTokenProfit = BigInt.fromI32(0)
+    limitOrderEntity.takerTokenProfitFee = BigInt.fromI32(0)
+    limitOrderEntity.takerTokenProfitBackToMaker = BigInt.fromI32(0)
+    limitOrderEntity.blockNumber = event.block.number
+    limitOrderEntity.blockTimestamp = event.block.timestamp
+    limitOrderEntity.transactionHash = event.transaction.hash
+  }
+  log.info('LimitOrderFilledByTrader entity created at transaction hash: {}, this entity id: {}.', [event.transaction.hash.toHex(), limitOrderEntity.id])
+  // Entity must be saved after setting
+  limitOrderEntity.save()
+}
+
+// Handling function when the OrderCancelled event occurs
+export function handleOrderCancelled(event: OrderCancelledEvent): void {
+  // Record the data of this OrderCancelled event
+  const eventId = getEventID(event)
+  const entity = new OrderCancelledEntity(eventId)
+  entity.orderHash = event.params.orderHash
+  entity.maker = event.params.maker
+  entity.blockNumber = event.block.number
+  entity.blockTimestamp = event.block.timestamp
+  entity.transactionHash = event.transaction.hash
+  // Entity must be saved after setting
+  entity.save()
+
+  // Get the order entity and set it to be canceled by maker
+  let orderEntity = OrderEntity.load(event.params.orderHash.toHex())
+  if (orderEntity != null) {
+    orderEntity.orderStatus = 'Cancelled'
+    orderEntity.lastFilledOrCancelledTime = event.block.timestamp
+    log.info('Order cancelled by maker at transaction hash: {}.', [event.transaction.hash.toHex()])
+    // Entity must be saved after setting
+    orderEntity.save()
+  }
+}

--- a/subgraphs/exchange/template.yaml
+++ b/subgraphs/exchange/template.yaml
@@ -110,3 +110,35 @@ dataSources:
           handler: handleSwappedTupple
       file: ./src/mapping_ammwrapper.ts
   {{/AMMV2}}
+  {{#LIMITORDERV1}}
+  - kind: ethereum/contract
+    name: {{ name }}
+    network: {{ network }}
+    source:
+      address: "{{ address }}"
+      abi: LimitOrder
+      startBlock: {{ startBlock }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - LimitOrderFilledByProtocol
+        - LimitOrderFilledByTrader
+        - OrderCancelled
+      abis:
+        - name: LimitOrder
+          file: ./abis/LimitOrder.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20Bytes
+          file: ./abis/ERC20Bytes.json
+      eventHandlers:
+        - event: LimitOrderFilledByProtocol(indexed bytes32,indexed address,indexed address,bytes32,address,address,(address,address,uint256,uint256,uint256,uint256,uint256),uint256,uint256,uint256)
+          handler: handleLimitOrderFilledByProtocol
+        - event: LimitOrderFilledByTrader(indexed bytes32,indexed address,indexed address,bytes32,address,(address,address,uint256,uint256,uint256,uint256,uint256))
+          handler: handleLimitOrderFilledByTrader
+        - event: OrderCancelled(bytes32,address)
+          handler: handleOrderCancelled
+      file: ./src/mapping_limitorder.ts
+  {{/LIMITORDERV1}}

--- a/subgraphs/exchange/template.yaml
+++ b/subgraphs/exchange/template.yaml
@@ -134,8 +134,8 @@ dataSources:
         - name: ERC20Bytes
           file: ./abis/ERC20Bytes.json
       eventHandlers:
-        - event: LimitOrderFilledByProtocol(indexed bytes32,indexed address,indexed address,bytes32,address,address,(address,address,uint256,uint256,uint256,uint256,uint256),uint256,uint256,uint256)
-          handler: handleLimitOrderFilledByProtocol
+        - event: {{ eventLimitOrderFilledByProtocol }}
+          handler: {{ handleLimitOrderFilledByProtocol }}
         - event: LimitOrderFilledByTrader(indexed bytes32,indexed address,indexed address,bytes32,address,(address,address,uint256,uint256,uint256,uint256,uint256))
           handler: handleLimitOrderFilledByTrader
         - event: OrderCancelled(bytes32,address)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,9 +1376,9 @@ glob@7.1.6, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
# Add LimitOrder subgraph to Exchange subgraph
- Order entity records the basic information and status of the order (e.g.: Cancelled or FullyFilled).
- LimitOrder entity records the basic information and status of the LimitOrder (e.g.: ByProtocol or ByTrader).
- Currently only the Goerli testnet version can be deployed to The Graph's Subgraph Studio service.
- Note: Only select 1 of these 2 PRs:
[https://github.com/consenlabs/tokenlon-v5-subgraph/pull/34](https://github.com/consenlabs/tokenlon-v5-subgraph/pull/34)
[https://github.com/consenlabs/tokenlon-v5-subgraph/pull/35](https://github.com/consenlabs/tokenlon-v5-subgraph/pull/35)

# How to verify
## 1.1 Verify subgraph deployment (for Goerli):
1. Go to [Subgraph Studio](https://thegraph.com/studio/) and create a Subgraph called "Tokenlon Exchange Goerli" with [Metamask Wallet](https://metamask.io/download/)
2. Prepare and compile
```shell
% yarn prepare:goerli && yarn codegen && yarn build
```
3. Deploy the tokenlon-v5-exchange
```shell
% graph auth --studio <Your_Deploy_Key>
% yarn workspace "tokenlon-v5-subgraph-exchange" run graph deploy --studio tokenlon-exchange-goerli exchange.yaml
```

## 1.2 Verify subgraph queries with deployed URL (for Goerli):
1. Or you can use the following URL that has been deployed to Subgraph Studio and use the [Public GraphQL](https://cloud.hasura.io/public/graphiql) website for query testing:
2. Deployed query URL:
```
https://api.studio.thegraph.com/query/34764/tokenlon-exchange-goerli/v0.0.7
```
3. Query GraphQL:
<details>
  <summary>(Please click here to expand)</summary>
    <pre><code>
query myQuery {
  limitOrderFilledByProtocols(
    first: 3
    orderBy: blockNumber
    orderDirection: desc
  ) {
    id
    orderHash
    maker
    taker
    blockNumber
    blockTimestamp
  }
  limitOrderFilledByTraders(first: 3, orderBy: blockNumber, orderDirection: desc) {
    id
    orderHash
    maker
    taker
    blockNumber
    blockTimestamp
  }
  limitOrders(first: 6, orderBy: blockNumber, orderDirection: desc) {
    id
    orderId
    maker
    taker
    limitOrderType
    blockNumber
    blockTimestamp
  }
  orders(first: 3, orderBy: lastFilledTime, orderDirection: desc) {
    id
    maker
    firstFilledTime
    lastFilledTime
  }
  orderCancelleds(first: 3, orderBy: blockNumber, orderDirection: desc) {
    id
    maker
  }
  fillOrders(orderBy: blockNumber, orderDirection: desc, first: 3) {
    id
    from
    to
  }
  swappeds(first: 3, orderBy: blockNumber, orderDirection: desc) {
    id
    from
    to
  }
}
    </code></pre>
</details>

4. Output:
<details>
  <summary>(Please click here to expand)</summary>
    <pre><code>
{
  "data": {
    "limitOrderFilledByProtocols": [
      {
        "id": "0x7eaea33242d9a8c627c7ddafaf5abb92cc02258ca005384f65630893d77d9ad7-0x0b9a13e30f6d87012956e26fd5e910daf655af65cb02e22be80ddc157b54afa4-171",
        "orderHash": "0xcb86f143394a2aafc77166c8ed7fbd5453ad9b86d7f50dac5cb96e1f3d5ea576",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "blockNumber": "8172665",
        "blockTimestamp": "1671592896"
      },
      {
        "id": "0xe4304131fdefacd2564f9ce8e270feb7e841977e1fcf3eb13a4fc47be12e1789-0xfdb7c0bc64cb8ea212c515891cf94d534d1b1071f57b09f0041c431e444861aa-94",
        "orderHash": "0xbbbcb054c219df982b2f2663623b4ff9954120a03158648d3cad0490278e73e6",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "blockNumber": "8166911",
        "blockTimestamp": "1671507588"
      },
      {
        "id": "0xbcf097f60373a996f9a619e3f058319479252663879560e679fab69d5561589b-0x6c6e4d5af88994c0f7c10346a5d3c5951a1e83c4b507ebac4a85729d9778d871-135",
        "orderHash": "0x82a3cff2a50319078d16f76bfaa3fa87e9835c2e86053c25b63d92a71cdbb6fb",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "blockNumber": "8166895",
        "blockTimestamp": "1671507348"
      }
    ],
    "limitOrderFilledByTraders": [],
    "limitOrders": [
      {
        "id": "0x7eaea33242d9a8c627c7ddafaf5abb92cc02258ca005384f65630893d77d9ad7-0x0b9a13e30f6d87012956e26fd5e910daf655af65cb02e22be80ddc157b54afa4-171",
        "orderId": "0xcb86f143394a2aafc77166c8ed7fbd5453ad9b86d7f50dac5cb96e1f3d5ea576",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "8172665",
        "blockTimestamp": "1671592896"
      },
      {
        "id": "0xe4304131fdefacd2564f9ce8e270feb7e841977e1fcf3eb13a4fc47be12e1789-0xfdb7c0bc64cb8ea212c515891cf94d534d1b1071f57b09f0041c431e444861aa-94",
        "orderId": "0xbbbcb054c219df982b2f2663623b4ff9954120a03158648d3cad0490278e73e6",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "8166911",
        "blockTimestamp": "1671507588"
      },
      {
        "id": "0xbcf097f60373a996f9a619e3f058319479252663879560e679fab69d5561589b-0x6c6e4d5af88994c0f7c10346a5d3c5951a1e83c4b507ebac4a85729d9778d871-135",
        "orderId": "0x82a3cff2a50319078d16f76bfaa3fa87e9835c2e86053c25b63d92a71cdbb6fb",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "8166895",
        "blockTimestamp": "1671507348"
      },
      {
        "id": "0xaf86f90e1e6dfa00e9a1e86146e192e337d76da6d62bb6af5461f401923eb4f8-0x99245735835d08a1d340fcace60e014956ed640c7d2a90839c399e1f968093d8-167",
        "orderId": "0x7b49835a388a9cbdd4ea82391c9d8224d1b1c5fad7593eb2a62ff1786dffcf09",
        "maker": "0x83f95c33d61ef8814db62f83490f31e2741d0507",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "7823869",
        "blockTimestamp": "1666584828"
      },
      {
        "id": "0x37f3b10db2bcf50c7520905eac58be72368bca12e97835b63c1f49741d2fff10-0x31790fc670bd134992746c2372ced9740004764cb89b7bda11fd06fe3c5eff98-114",
        "orderId": "0x542cc0c016def1ec97b4077969f2ade55b524447c8011132eee2e77caf6c2bc1",
        "maker": "0x4031e602f315e37ec17415740fd24605372911b6",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "7732903",
        "blockTimestamp": "1665222396"
      },
      {
        "id": "0x5ac382616f9dce947a151c38b31817c47959b675f9515df9a38671a2e41c53c3-0xe94aa16401548493650ae482a695e71074d610f8413a3ed0293bcb52fbffc3a3-55",
        "orderId": "0x93853d95c0d9f83b28222c32b570fd65bf52832ec8339a55cb5df010e45a981a",
        "maker": "0x4031e602f315e37ec17415740fd24605372911b6",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "7730458",
        "blockTimestamp": "1665186168"
      }
    ],
    "orders": [
      {
        "id": "0xcb86f143394a2aafc77166c8ed7fbd5453ad9b86d7f50dac5cb96e1f3d5ea576",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "firstFilledTime": "1671592896",
        "lastFilledTime": "1671592896"
      },
      {
        "id": "0xbbbcb054c219df982b2f2663623b4ff9954120a03158648d3cad0490278e73e6",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "firstFilledTime": "1671507588",
        "lastFilledTime": "1671507588"
      },
      {
        "id": "0x82a3cff2a50319078d16f76bfaa3fa87e9835c2e86053c25b63d92a71cdbb6fb",
        "maker": "0x83f6cc067980f6282a5f1950636f85e38fd0e027",
        "firstFilledTime": "1671507348",
        "lastFilledTime": "1671507348"
      }
    ],
    "orderCancelleds": [],
    "fillOrders": [
      {
        "id": "0x92f56e9cc411f2ea8a48796a64e5271d01d2d05a897998533d1dfff636f0fffe-0x188b890750258737492d2921dde8dc7e96914f12841640f6bc84d47e1873d3f8-53",
        "from": "0x4031e602f315e37ec17415740fd24605372911b6",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      },
      {
        "id": "0xc43626f9367bd5105ee438afb6ce97a163cd91e667682520548a79d176d7fef8-0xde657ef1508bdfcd3d32638289a407c1994e2b7e6e660df803a7ffb42b3c8658-11",
        "from": "0xc8ddfb4f7faeab85d40ea96c64ad2647934e3c2f",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      },
      {
        "id": "0x9297f294521acc112707db3c9a0384c4b1c005ea7d54c2dafc61d40d6a8f1ca4-0x3f43720eda3d743e406e407cdc05a36db8eae169cb8156b73b3292c65c9dbb78-5",
        "from": "0xb089b5f87d76bc5c31ebadacbab78aac95e70f85",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      }
    ],
    "swappeds": [
      {
        "id": "0x4f95417f3ae205e72aa11ee81f3b8c56724a1df9a62457ee5a987459b8c5dc0a-0x3c4771d086d291ab52423359d20b8c5712875b88475467e0c47c5ab63fee12dd-11",
        "from": "0xd7a0d7889577ef77c11ab5cc00817d1c9ade6b36",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      },
      {
        "id": "0xafc36429847f1fb0b12226266322ddd51bf44ee191ab5f4b6dd1e80dd0d82287-0x1cd7546dc895727b6407affda9a1f5977b27c99a22c4ad821b894a949203f7fe-11",
        "from": "0xd7a0d7889577ef77c11ab5cc00817d1c9ade6b36",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      },
      {
        "id": "0x6d3a05138f331238ac48959866844a20b651bd005fa60b514612180af0de0611-0x27e2e29acf335a322ca95b28c96a953844e450f344b7340971509aacb03010a0-14",
        "from": "0xd7a0d7889577ef77c11ab5cc00817d1c9ade6b36",
        "to": "0x25657705a6be20511687d483f2fccfb2d92f6033"
      }
    ]
  }
}
    </code></pre>
</details>

## 2.1 Verify subgraph deployment (for Mainnet):
1. Go to [Subgraph Studio](https://thegraph.com/studio/) and create a Subgraph called "Tokenlon Exchange Mainnet" with [Metamask Wallet](https://metamask.io/download/)
2. Prepare and compile
```shell
% yarn prepare:mainnet && yarn codegen && yarn build
```
3. Deploy the tokenlon-exchange
```shell
% graph auth --studio <Your_Deploy_Key>
% yarn workspace "tokenlon-v5-subgraph-exchange" run graph deploy --studio tokenlon-exchange-mainnet exchange.yaml
```

## 2.2 Verify subgraph queries with deployed URL (for Mainnet):
1. Or you can use the following URL that has been deployed to Subgraph Studio and use the [Public GraphQL](https://cloud.hasura.io/public/graphiql) website for query testing:
2. Deployed query URL:
```
https://api.studio.thegraph.com/query/34764/tokenlon-exchange-mainnet/v0.0.15
```
3. Query GraphQL:
(Same as before)

4. Output (No LimitOrder data):
<details>
  <summary>(Please click here to expand)</summary>
    <pre><code>
{
  "data": {
    "limitOrderFilledByProtocols": [
      {
        "id": "0x30d1dd8e56b896b7add8d805511116d48a0d4d0b147767163abf7ceec17bb69f-0x6fe78a977ff9f12d613463338b840a17ba7746cf17241b4e5d62bcdce19646a5-127",
        "orderHash": "0x47d392fae3fa4407b9fc0f45e00e0cb0a5745b17efc6104d5899428645a75f1d",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "blockNumber": "16577379",
        "blockTimestamp": "1675778687"
      },
      {
        "id": "0x3c9db1e656b91361c2e99022750d7de78beda877e641ea14f92e269558749f58-0x4cf676699ae2bc3dbde99eba1e1d473187cab55ab86d245820855ceef73d8ea0-210",
        "orderHash": "0x90a3e0fada4444670862aa9d5f2625c302fc2f28f886cb2b900fae6d1085a5d9",
        "maker": "0xe49c9f7308404c1630129513c8d0da5cfec8e854",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "blockNumber": "16570692",
        "blockTimestamp": "1675697915"
      }
    ],
    "limitOrderFilledByTraders": [
      {
        "id": "0xd927d0cf7c77d87f1682d394303f15a9bc24f8906ff07774121d2a32b6461ef0-0x90b85259ca573034ab2dcbfde8beddc617ea377edaa80bc07cb8fa479857caac-129",
        "orderHash": "0xa811da68b53407bc8f15dd078161f1db256221049ae6468baa701ed56aaabc44",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "blockNumber": "16582624",
        "blockTimestamp": "1675841939"
      },
      {
        "id": "0x44b0498fd37ef79220db8bb81178b178f1479e10f6f18a11221d74e0cf13c231-0x4e278c095ce131f6b42f85c86a9913ced07c1767d2f73c363713ca09a62c699c-400",
        "orderHash": "0xcb170534563fecaa76fa6f638c2ee55e6c4df9c91698eb799885646e0f0a7c6b",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "blockNumber": "16582206",
        "blockTimestamp": "1675836899"
      },
      {
        "id": "0xd4733cfd983c2567a8a3f6e8dd62560a87189a7d24279c77bd19c2feea3d4fd9-0xb035d271ff09ed8ff7df5722b91a2a7ef3edff419697fe0ef00b38aed15932fb-106",
        "orderHash": "0xe206ac28c4f6b18cb2b1a886c2ddc1c37b2a3b5710c220e0f6c41db36785e690",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "blockNumber": "16575972",
        "blockTimestamp": "1675761635"
      }
    ],
    "limitOrders": [
      {
        "id": "0xd927d0cf7c77d87f1682d394303f15a9bc24f8906ff07774121d2a32b6461ef0-0x90b85259ca573034ab2dcbfde8beddc617ea377edaa80bc07cb8fa479857caac-129",
        "orderId": "0xa811da68b53407bc8f15dd078161f1db256221049ae6468baa701ed56aaabc44",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "limitOrderType": "ByTrader",
        "blockNumber": "16582624",
        "blockTimestamp": "1675841939"
      },
      {
        "id": "0x44b0498fd37ef79220db8bb81178b178f1479e10f6f18a11221d74e0cf13c231-0x4e278c095ce131f6b42f85c86a9913ced07c1767d2f73c363713ca09a62c699c-400",
        "orderId": "0xcb170534563fecaa76fa6f638c2ee55e6c4df9c91698eb799885646e0f0a7c6b",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "limitOrderType": "ByTrader",
        "blockNumber": "16582206",
        "blockTimestamp": "1675836899"
      },
      {
        "id": "0x30d1dd8e56b896b7add8d805511116d48a0d4d0b147767163abf7ceec17bb69f-0x6fe78a977ff9f12d613463338b840a17ba7746cf17241b4e5d62bcdce19646a5-127",
        "orderId": "0x47d392fae3fa4407b9fc0f45e00e0cb0a5745b17efc6104d5899428645a75f1d",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "16577379",
        "blockTimestamp": "1675778687"
      },
      {
        "id": "0xd4733cfd983c2567a8a3f6e8dd62560a87189a7d24279c77bd19c2feea3d4fd9-0xb035d271ff09ed8ff7df5722b91a2a7ef3edff419697fe0ef00b38aed15932fb-106",
        "orderId": "0xe206ac28c4f6b18cb2b1a886c2ddc1c37b2a3b5710c220e0f6c41db36785e690",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "taker": "0x632da2cb89e08449c75e7a4e022189e3d6af8a2b",
        "limitOrderType": "ByTrader",
        "blockNumber": "16575972",
        "blockTimestamp": "1675761635"
      },
      {
        "id": "0x3c9db1e656b91361c2e99022750d7de78beda877e641ea14f92e269558749f58-0x4cf676699ae2bc3dbde99eba1e1d473187cab55ab86d245820855ceef73d8ea0-210",
        "orderId": "0x90a3e0fada4444670862aa9d5f2625c302fc2f28f886cb2b900fae6d1085a5d9",
        "maker": "0xe49c9f7308404c1630129513c8d0da5cfec8e854",
        "taker": "0xe592427a0aece92de3edee1f18e0157c05861564",
        "limitOrderType": "ByProtocol",
        "blockNumber": "16570692",
        "blockTimestamp": "1675697915"
      }
    ],
    "orders": [
      {
        "id": "0xa811da68b53407bc8f15dd078161f1db256221049ae6468baa701ed56aaabc44",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "firstFilledTime": "1675841939",
        "lastFilledTime": "1675841939"
      },
      {
        "id": "0xcb170534563fecaa76fa6f638c2ee55e6c4df9c91698eb799885646e0f0a7c6b",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "firstFilledTime": "1675836899",
        "lastFilledTime": "1675836899"
      },
      {
        "id": "0x47d392fae3fa4407b9fc0f45e00e0cb0a5745b17efc6104d5899428645a75f1d",
        "maker": "0x3b7fda9022942273a8a104d2bf3f43450735989c",
        "firstFilledTime": "1675778687",
        "lastFilledTime": "1675778687"
      }
    ],
    "orderCancelleds": [],
    "fillOrders": [
      {
        "id": "0x2824f5e0bf8d3128bf9c359c8b4a7c0a9a9837493762d8d613acae5eede3b9bc-0x03877d58017b8e25f60fe1fd3804101b3c1cd747abbaad240c21fb42f250beab-89",
        "from": "0xbec3bac7f4263db554808b77cdc16104cf0f3798",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      },
      {
        "id": "0x06fd5df028980be0e8c22eb2cbd9d8b7992a99bebb155720182b34a22dc0996a-0x41c07cc7c4cd05f768cc92c755327c73ef3636c2430a819a7538fb38a0753d67-248",
        "from": "0x10272e34e2952ba284587d9a02c5247ae326135f",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      },
      {
        "id": "0xc4221e604d4b7a64552e698989ad4965c6b4768bfb51ec3ce4c903229f804d9f-0x9e2506399a7ad6797ca443d4009eb69de6c4f9c13c58ec022398339a26d4fd86-334",
        "from": "0x48c5213c2fa8b7aca95dc09f442d83fc8336745f",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      }
    ],
    "swappeds": [
      {
        "id": "0x99add251f60a82233b45c37fa3bdc1b6fb90775dd8626aef31862efcfc95a498-0x370114fe6231430dda0df57f9c544ca4c1d3f6456cfbc6e81fb752c59bc74ce9-175",
        "from": "0x48c5213c2fa8b7aca95dc09f442d83fc8336745f",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      },
      {
        "id": "0xd9a23ac957d1f22f0a8a43db0c9032bea8ef9468e31625648d678fbc9ad40eef-0x918ac5f84a23b9ea0a147e7f725eb1f91a415fabc35aba2e8ef5eae4afb5226b-162",
        "from": "0xf76698d6d3439110fdfaf10dcd556f201bfea8d1",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      },
      {
        "id": "0xe7f5c84e74316f1446bcfadd7fff84a56051d761fd3e6766f933050f9b436949-0xe953c8a42fa6118e4f429cda3c24574d45819867f51fd6e10330d5cc6b9952af-232",
        "from": "0xa1021e8b5fd3207ea4ed43aa633174ddca9ba625",
        "to": "0x03f34be1bf910116595db1b11e9d1b2ca5d59659"
      }
    ]
  }
}
    </code></pre>
</details>

## 2.3 Verify notes
- You can then use the Tokenlon Exchange subgraph playground that is currently online to verify the query results (Need to remove LimitOrder query part):
[https://thegraph.com/hosted-service/subgraph/consenlabs/tokenlon-v5-exchange](https://thegraph.com/hosted-service/subgraph/consenlabs/tokenlon-v5-exchange)